### PR TITLE
Bumps this action to use Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,5 +4,5 @@ inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "round_linker",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "",
   "main": "src/index.js",


### PR DESCRIPTION
https://github.com/tgstation/tgstation/actions/runs/10445941501

![image](https://github.com/user-attachments/assets/0f299199-bf8f-4247-b772-f73fc7daa339)

GitHub keeps getting mad at us for still using Node12 and autoruns this action on Node16/20 anyways so let's just bump it up to lessen the number of errors we have on tgstation/tgstation

i don't think there's any issues but i've been wrong before. wait i have a fork let me check