### PR TITLE
Round ID Links To Statbus

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Round ID Linker
 
-Replaces round id's in issue body with links to scrubby.
+Replaces round id's in issue body with links to statbus.
 Accepted round id format :
 ```
 [Round ID]: 1245

--- a/dist/index.js
+++ b/dist/index.js
@@ -21782,7 +21782,7 @@ async function createLinks(client, issue_number, issue_body) {
   let re = /(\[?Round ID\]?:\s*)(\d+)/g
   if(issue_body.match(re))
   {
-    const new_body = issue_body.replace(re, "$1[$2](https://scrubby.melonmesa.com/round/$2)");
+    const new_body = issue_body.replace(re, "$1[$2](https://statbus.space/round/$2)");
 
     const getResponse = await client.issues.update({
       owner: github.context.repo.owner,

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ async function createLinks(client, issue_number, issue_body) {
   let re = /(\[?Round ID\]?:\s*)(\d+)/g
   if(issue_body.match(re))
   {
-    const new_body = issue_body.replace(re, "$1[$2](https://scrubby.melonmesa.com/round/$2)");
+    const new_body = issue_body.replace(re, "$1[$2](https://statbus.space/round/$2)");
 
     const getResponse = await client.issues.update({
       owner: github.context.repo.owner,


### PR DESCRIPTION
We now link to statbus not scrubby. I mistakenly assumed my PR on mothbus repo would fix it but it did not. It should be done here

- https://github.com/tgstation/tgstation/issues/93430