### PR TITLE
Bump action to Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,5 +4,5 @@ inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
See [Migration](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

It is recommended to first merge
- #6
- #7
- #8

because they might be needed for this to run on Node 24 but I'm not sure. Just a precaution